### PR TITLE
Ability to specify the target directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ module.exports = function(grunt) {
            
            // function to post-process file’s content before it will be
            // saved to disk
-           postProcess: function(content, fileInfo) {}
+           postProcess: function(content, fileInfo) {},
+
+           // Directory to output .build-catalog.js and bundles
+           targetdir: '../vat/tmp',
+
+           // Only process .build-catalog.js (no bundles)
+           onlyCatalog: true
     	},
     	
     	// Task for concatenating and minifying JS files

--- a/tasks/frontend.js
+++ b/tasks/frontend.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
 	function factory(fn) {
 		return function() {
 			var config = utils.config(grunt, this);
-			var map = catalog.load();
+			var map = catalog.load(config);
 			fn(config, map, {grunt: grunt, task: this});
 			catalog.save(map);
 		};

--- a/tasks/lib/catalog.js
+++ b/tasks/lib/catalog.js
@@ -1,15 +1,24 @@
 var fs = require('fs');
+var path = require('path');
 var catalogFile = '.build-catalog.json';
+var catalogPath;
 
 module.exports = {
+	getCatalogPath: function (config) {
+		catalogPath = catalogPath ||
+		path.resolve(path.join(config.targetdir || '.', catalogFile));
+		return catalogPath;
+	},
+
 	/**
 	 * Loads catalog for current project. If catalog doesn’t exists,
 	 * empty object is returned
 	 * @return {Object}
 	 */
-	load: function() {
-		if (fs.existsSync(catalogFile)) {
-			var content = fs.readFileSync(catalogFile);
+	load: function(config) {
+		var catalogPath = this.getCatalogPath(config);
+		if (fs.existsSync(catalogPath)) {
+			var content = fs.readFileSync(catalogPath);
 			return JSON.parse(content);
 		}
 
@@ -20,11 +29,11 @@ module.exports = {
 	 * Saves given content in catalog file
 	 * @param {Object} content Catalog content
 	 */
-	save: function(content) {
+	save: function(content, config) {
 		if (typeof content != 'string') {
 			content = JSON.stringify(content, null, '\t');
 		}
 
-		fs.writeFileSync(catalogFile, content);
+		fs.writeFileSync(this.getCatalogPath(config), content);
 	}
 };

--- a/tasks/lib/javascript.js
+++ b/tasks/lib/javascript.js
@@ -45,6 +45,15 @@ function validFiles(files, grunt, config) {
 		});
 }
 
+function stripSourcePrefix (sourceMap, prefix) {
+	var prefix = new RegExp('^' + prefix);
+	sourceMap = JSON.parse(sourceMap);
+	sourceMap.sources = sourceMap.sources.map(function (path) {
+		return path.replace(prefix, '');
+	});
+	return JSON.stringify(sourceMap);
+}
+
 module.exports = {
 	/**
 	 * Returns config for UglifyJS
@@ -112,6 +121,10 @@ module.exports = {
 			if (!config.onlyCatalog) {
 				grunt.file.write(dest.targetPath, dest.content);
 				if (dest.map) {
+					// strip trailing prefix in source pathes and write file
+					if (config.sourcePrefix) {
+						dest.map = stripSourcePrefix(dest.map, config.sourcePrefix)
+					}
 					grunt.file.write(dest.targetPath + '.map', dest.map);
 				}
 				grunt.log.writeln(' [save]'.green);

--- a/tasks/lib/utils.js
+++ b/tasks/lib/utils.js
@@ -13,6 +13,7 @@ function FileInfo(file, options) {
 	this._path = file;
 	this.absPath = module.exports.absPath(file, options.cwd);
 	this.catalogPath = module.exports.catalogPath(file, options);
+	this.targetPath = module.exports.absPath(path.join(options.targetdir || '.', file), options.cwd),
 	this._hash = null;
 	this._content = null;
 	this._options = options || {};


### PR DESCRIPTION
I'm adding two things in grunt config:
- targetdir - output directory, i.e. '../var/tmp',
- onlyCatalog - only build-catalog (no bundles)

+fix uglify call and sourceMap output

Please approve. Tests passed.
